### PR TITLE
replace the use of `SafeConfigParser` with bogstandard `ConfigParser` (and use direct import of `configparser`, not via `six` anymore)

### DIFF
--- a/myproxy/client/utils/__init__.py
+++ b/myproxy/client/utils/__init__.py
@@ -8,14 +8,14 @@ __date__ = "15/12/08"
 __copyright__ = "Copyright 2018 United Kingdom Research and Innovation"
 __license__ = """BSD - See LICENSE file in top-level package directory"""
 __contact__ = "Philip.Kershaw@stfc.ac.uk"
-from six.moves.configparser import SafeConfigParser
+from configparser import ConfigParser
 
 
-class CaseSensitiveConfigParser(SafeConfigParser):
+class CaseSensitiveConfigParser(ConfigParser):
     '''Subclass the SafeConfigParser - to preserve the original string case of
     config section names
     '''
     def optionxform(self, optionstr):
-        '''Extend SafeConfigParser.optionxform to preserve case of option names
+        '''Extend ConfigParser.optionxform to preserve case of option names
         '''
         return optionstr

--- a/myproxy/client/utils/openssl.py
+++ b/myproxy/client/utils/openssl.py
@@ -12,14 +12,14 @@ import re
 import os
 
 import six
-from six.moves.configparser import SafeConfigParser
+from configparser import ConfigParser
 
 
 class OpenSSLConfigError(Exception):
     """Exceptions related to OpenSSLConfig class"""
 
 
-class OpenSSLConfig(SafeConfigParser, object):
+class OpenSSLConfig(ConfigParser, object):
     """Wrapper to OpenSSL Configuration file to allow extraction of
     required distinguished name used for making certificate requests
 


### PR DESCRIPTION
Closes #19 

Hi Phil, please see my proposed change from the now completely retired `SafeConfigParser` in Python=3.12 to the bogstandard `ConfigParser` - I also removed the import via `six` even though I think Py2 functionality is still there via the checks for Py2 string types - but, if I was you, I'd remove that altogether and just support Py3 :beer: 