### PR TITLE
Add Github Actions workflow that builds a PyPI package (and deploys it on PyPI if Github release) + simple test with barebones conda environment file

### DIFF
--- a/.github/workflows/build-and-deploy-on-pypi.yml
+++ b/.github/workflows/build-and-deploy-on-pypi.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - add_pypi_pkg_build_GA
 
 jobs:
   build-n-publish:

--- a/.github/workflows/build-and-deploy-on-pypi.yml
+++ b/.github/workflows/build-and-deploy-on-pypi.yml
@@ -1,0 +1,48 @@
+name: PyPi Build and Deploy 🐍📦
+
+on:
+  release:
+    types: [published]
+  # use this for testing
+  push:
+    branches:
+      - main
+      - add_pypi_pkg_build_GA
+
+jobs:
+  build-n-publish:
+    name: Build and publish MyProxyClient on PyPi
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+      - name: Install pep517
+        run: >-
+          python -m
+          pip install
+          pep517
+          --user
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python -m
+          pep517.build
+          --source
+          --binary
+          --out-dir dist/
+          .
+      #- name: Publish distribution 📦 to Test PyPI
+      #  uses: pypa/gh-action-pypi-publish@master
+      #  with:
+      #    password: ${{ secrets.test_pypi_password }}
+      #    repository_url: https://test.pypi.org/legacy/
+      - name: Publish distribution 📦 to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/build-and-deploy-on-pypi.yml
+++ b/.github/workflows/build-and-deploy-on-pypi.yml
@@ -47,7 +47,9 @@ jobs:
           --out-dir dist/
           .
       - name: Publish distribution 📦 to Test PyP
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build-and-deploy-on-pypi.yml
+++ b/.github/workflows/build-and-deploy-on-pypi.yml
@@ -12,6 +12,11 @@ jobs:
   build-n-publish:
     name: Build and publish MyProxyClient on PyPi
     runs-on: ubuntu-latest
+    # use the new Trusted Publishers feature
+    # details at https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -42,6 +47,8 @@ jobs:
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
+      # this is the old token and password way;
+      # we are using the new Truster Publishers (see above)
+      #  with:
+      #    user: __token__
+      #    password: ${{ secrets.pypi_password }}

--- a/.github/workflows/build-and-deploy-on-pypi.yml
+++ b/.github/workflows/build-and-deploy-on-pypi.yml
@@ -45,16 +45,8 @@ jobs:
           --binary
           --out-dir dist/
           .
-      #- name: Publish distribution 📦 to Test PyPI
-      #  uses: pypa/gh-action-pypi-publish@master
-      #  with:
-      #    password: ${{ secrets.test_pypi_password }}
-      #    repository_url: https://test.pypi.org/legacy/
+      - name: Publish distribution 📦 to Test PyP
+        uses: pypa/gh-action-pypi-publish@master
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
-      # this is the old token and password way;
-      # we are using the new Truster Publishers (see above)
-      #  with:
-      #    user: __token__
-      #    password: ${{ secrets.pypi_password }}

--- a/.github/workflows/build-and-deploy-on-pypi.yml
+++ b/.github/workflows/build-and-deploy-on-pypi.yml
@@ -13,7 +13,6 @@ jobs:
   build-n-publish:
     name: Build and publish MyProxyClient on PyPi
     runs-on: ubuntu-latest
-    # may also need this for publishing?
     environment:
       name: pypi
       url: https://pypi.org/project/MyProxyClient/
@@ -46,10 +45,10 @@ jobs:
           --binary
           --out-dir dist/
           .
-      - name: Publish distribution 📦 to Test PyP
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
+      # - name: Publish distribution 📦 to Test PyP
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     repository-url: https://test.pypi.org/legacy/
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build-and-deploy-on-pypi.yml
+++ b/.github/workflows/build-and-deploy-on-pypi.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - add_pypi_pkg_build_GA
 
 jobs:
   build-n-publish:

--- a/.github/workflows/build-and-deploy-on-pypi.yml
+++ b/.github/workflows/build-and-deploy-on-pypi.yml
@@ -12,8 +12,14 @@ jobs:
   build-n-publish:
     name: Build and publish MyProxyClient on PyPi
     runs-on: ubuntu-latest
+    # may also need this for publishing?
+    environment:
+      name: pypi
+      url: https://pypi.org/project/MyProxyClient/
     # use the new Trusted Publishers feature
     # details at https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
+    # to add a PyPI project to Trusted Publishers, see
+    # https://docs.pypi.org/trusted-publishers/adding-a-publisher/
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - add_pypi_pkg_build_GA
   schedule:
     - cron: '0 0 * * *'  # nightly
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,39 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+      - add_pypi_pkg_build_GA
+  schedule:
+    - cron: '0 0 * * *'  # nightly
+
+# Required shell entrypoint to have properly configured bash shell
+defaults:
+  run:
+    shell: bash -l {0}
+
+jobs:
+  linux:
+    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+      fail-fast: false
+    name: Linux Python ${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: myproxy
+          environment-file: environment-test.yml
+          python-version: ${{ matrix.python-version }}
+          miniforge-version: "latest"
+          miniforge-variant: Mambaforge
+          use-mamba: true
+      - run: conda --version
+      - run: python -V
+      - run: pip install -e .
+      - run: pytest tests/unit/test_simple.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 MyProxyClient.egg-info/
 build/
 dist/
-myproxy/client/__pycache__/
-myproxy/client/utils/__pycache__/
-tests/unit/__pycache__/
+__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 MyProxyClient.egg-info/
 build/
 dist/
+myproxy/client/__pycache__/
+myproxy/client/utils/__pycache__/
+tests/unit/__pycache__/

--- a/environment-test.yml
+++ b/environment-test.yml
@@ -1,0 +1,9 @@
+---
+name: myproxy
+channels:
+  - conda-forge
+  - nodefaults
+
+dependencies:
+  - pip
+  - pytest

--- a/myproxy/client/utils/__init__.py
+++ b/myproxy/client/utils/__init__.py
@@ -12,7 +12,7 @@ from configparser import ConfigParser
 
 
 class CaseSensitiveConfigParser(ConfigParser):
-    '''Subclass the SafeConfigParser - to preserve the original string case of
+    '''Subclass ConfigParser - to preserve the original string case of
     config section names
     '''
     def optionxform(self, optionstr):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 40.6.0", "wheel", "setuptools_scm>=6.2"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     version =         	'2.1.1',
     description =     	'MyProxy Client',
     long_description = 	LONG_DESCR,
+    long_description_content_type='text/markdown',
     author =          	'Philip Kershaw',
     author_email =    	'Philip.Kershaw@stfc.ac.uk',
     maintainer =        'Philip Kershaw',

--- a/tests/unit/test_simple.py
+++ b/tests/unit/test_simple.py
@@ -1,0 +1,26 @@
+from myproxy.client import MyProxyClient
+
+
+def test_members():
+    """Test public method members of MyProxyClient."""
+    expected_members = [
+        'caCertDir', 'changePassphrase', 'destroy', 'getDelegation',
+        'getTrustRoots', 'hostname', 'info', 'locateClientCredentials',
+        'logon', 'openSSLConfFilePath', 'openSSLConfig', 'parseConfig',
+        'port', 'proxyCertLifetime', 'proxyCertMaxLifetime', 'put',
+        'readProxyFile', 'serverDN', 'setDefaultCACertDir',
+        'ssl_verification', 'store', 'writeProxyFile'
+    ]
+    actual_members = dir(MyProxyClient)
+    for member in expected_members:
+        assert member in actual_members
+
+
+def test_simple():
+    """Test a simple instance of MyProxyClient."""
+    hostname = "www.google.com"
+    c = MyProxyClient(hostname=hostname, caCertDir="")
+    assert c.hostname == "www.google.com"
+    assert not c.caCertDir
+    assert c.proxyCertLifetime == 43200
+    assert not c.serverDN

--- a/tests/unit/test_simple.py
+++ b/tests/unit/test_simple.py
@@ -18,9 +18,9 @@ def test_members():
 
 def test_simple():
     """Test a simple instance of MyProxyClient."""
-    hostname = "www.google.com"
+    hostname = "example.com"
     c = MyProxyClient(hostname=hostname, caCertDir="")
-    assert c.hostname == "www.google.com"
+    assert c.hostname == "example.com"
     assert not c.caCertDir
     assert c.proxyCertLifetime == 43200
     assert not c.serverDN


### PR DESCRIPTION
I've added a convenient PyPI package builder Github Action that builds it with the latest supported Python (nominally Python=3.12 since #19 #20 and the final #21 ), and the upload should be automated via a token that we'd have to upload to PyPI. I am also adding a barebones `pyproject.toml` file to be used with the pkg build; the build seems to [run well](https://github.com/cedadev/MyProxyClient/actions/runs/6853071338/job/18633058138?pr=22) - the upload (in case of release) can only happen if we upload the token to PyPI - do any of you gets want to do that?

EDIT: waiting for good man @philipkershaw to make me an owner of the PyPI repo, I have also added a barebones unit test + barebones conda env file to have the test run on multiple Python versions