### PR TITLE
Eliminate deprecation warnings that will soon be hard failures

### DIFF
--- a/myproxy/__init__.py
+++ b/myproxy/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
> [!WARNING]
>
> If this change is accepted and merged, _a new version of MyProxyClient will need to be released quickly_ so that downstream projects that rely on MyProxyClient do not experience hard failures in the future!

This change addresses the following warnings, which may become hard failures in the next three months!

```
myproxy/__init__.py:1: UserWarning:
pkg_resources is deprecated as an API.
See https://setuptools.pypa.io/en/latest/pkg_resources.html.
The pkg_resources package is slated for removal as early as 2025-11-30.
Refrain from using this package or pin to Setuptools<81.
  __import__('pkg_resources').declare_namespace(__name__)
```

and

```
myproxy/__init__.py:1: DeprecationWarning:
Deprecated call to `pkg_resources.declare_namespace('myproxy')`.
Implementing implicit namespace packages (as specified in PEP 420)
is preferred to `pkg_resources.declare_namespace`.
  __import__('pkg_resources').declare_namespace(__name__)
```

This may have been a compatibility hack when Python 2 was supported but it doesn't appear to be needed, and is likely to cause failures in the near-term future.